### PR TITLE
configurable retries for waiting for seafile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See docker-compose how to use.
  - USERNAME=username                 Your account username (credentials)
  - PASSWORD=password                 Your account password (credentials)
  - DATA_DIR=directory-path-to-sync   The path where to put the files
-
+ - CONNECT_RETRIES=number            How many times try to connect to daemon. Higher value is useful on slow boxes. Default is 5
 ## How to find library id:
 
 <img src="imgs/help.png"/>

--- a/start.sh
+++ b/start.sh
@@ -7,9 +7,10 @@ set -o pipefail
 DATA_DIR="${DATA_DIR:-/data}"
 SEAFILE_UID="${SEAFILE_UID:-1000}"
 SEAFILE_GID="${SEAFILE_GID:-1000}"
+CONNECT_RETRIES="${CONNECT_RETRIES:-5}"
 
 start_seafile(){
-  retries=5
+  retries="${CONNECT_RETRIES}"
   count=0
   su - seafile -c "seaf-cli start"
   set +e


### PR DESCRIPTION
On some weak boxes (e.g. older synology stations) daemon starts for very long time, especially on first run. So instead of killing the container you can configure more retries.

5 retries default is more than enough on fast boxes.