### PR TITLE
Deal with parentheses in library name

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -94,6 +94,7 @@ keep_in_foreground() {
       pkill -0 -f "${SEAFILE_PROC}"
       sleep 1
     done
+    date +"%Y-%m-%d %H:%M:%S"
     su - seafile -c "seaf-cli status"
     sleep 5
   done

--- a/start.sh
+++ b/start.sh
@@ -39,7 +39,8 @@ get () {
     NAME="$1"
     JSON="$2"
     # Tries to regex setting name from config. Only works with strings for now
-    VALUE=$(echo $JSON | grep -Po '"'"$NAME"'"\s*:\s*.*?[^\\]"+,*' | sed -n -e 's/.*: *"\(.*\)",*/\1/p')
+    VALUE=$(echo $JSON | grep -Po '"'"$NAME"'"\s*:\s*.*?[^\\]"+,*' | sed -n -e 's/.*: *"\(.*\)",*/\1/p'|sed -e 's#[\(\)]#\\\0#g')
+
     # Use eval to ensure that nested expressens are executed (config points to environment var)
     eval echo $VALUE
 }
@@ -59,7 +60,7 @@ setup_lib_sync(){
       LIB="${LIBS[i]}"
       LIB_JSON=$(curl -G -H "Authorization: Token $TOKEN" -H 'Accept: application/json; indent=4' ${SERVER_URL}:${SERVER_PORT}/api2/repos/${LIB}/ 2> /dev/null)
       LIB_NAME=$(get name "$LIB_JSON")
-      LIB_NAME_NO_SPACE=${LIB_NAME// /_}
+      LIB_NAME_NO_SPACE=$(echo $LIB_NAME|sed 's/[ \(\)]/_/g')
       LIB_DIR=${DATA_DIR}/${LIB_NAME_NO_SPACE}
       set +e
       LIB_IN_SYNC=$(echo "$LIBS_IN_SYNC" | grep "$LIB")

--- a/start.sh
+++ b/start.sh
@@ -96,7 +96,7 @@ keep_in_foreground() {
     done
     date +"%Y-%m-%d %H:%M:%S"
     su - seafile -c "seaf-cli status"
-    sleep 5
+    sleep 60
   done
 }
 


### PR DESCRIPTION
If the library name is something like
```
Library (abc)
```
startup script throws error during `eval echo $VALUE` , because it tries to interpret the parentheses. So added escape characters to output of json.

Also added replacement for parentheses by underscore, same as for spaces. Linux can deal with parentheses, but it makes issues when e.g. sharing the synced folder via SMB or other network protocols.