### PR TITLE
Update to work with current version (as of 2024-08-16), and allow for persistent seafile state across container instantiations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,16 @@ RUN apt-get install -y seafile-cli
 RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get clean
 
-WORKDIR /seafile-client
+RUN mkdir /seafile-state
+RUN mkdir /home/seafile
 
-COPY start.sh /seafile-client/start.sh
+WORKDIR /home/seafile
 
-RUN chmod +x /seafile-client/start.sh
-RUN useradd -U -d /seafile-client -s /bin/bash seafile
+COPY start.sh /home/seafile/start.sh
+RUN chmod +x /home/seafile/start.sh
+
+RUN useradd -U -d /home/seafile -s /bin/bash seafile
 RUN usermod -G users seafile
-RUN chown seafile:seafile -R /seafile-client
-RUN su - seafile -c "seaf-cli init -d /seafile-client"
+RUN chown seafile:seafile -R /home/seafile
 
 CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install gnupg curl -y
+RUN apt-get update && apt-get install procps grep curl -y
 RUN curl https://linux-clients.seafile.com/seafile.asc -o /usr/share/keyrings/seafile-keyring.asc
 RUN echo deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/bullseye/ stable main | tee /etc/apt/sources.list.d/seafile.list
 RUN apt-get update -y
-RUN apt-get install -y seafile-cli procps grep
+RUN apt-get install -y seafile-cli
 RUN rm -rf /var/lib/apt/lists/*
 RUN apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,21 @@
 FROM debian:bullseye-slim
 
-RUN apt-get update && apt-get install gnupg curl -y && \
-    curl https://linux-clients.seafile.com/seafile.asc -o /usr/share/keyrings/seafile-keyring.asc && \
-    echo deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/bullseye/ stable main | tee /etc/apt/sources.list.d/seafile.list && \
-    apt-get update -y && \
-    apt-get install -y seafile-cli procps grep && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
+RUN apt-get update && apt-get install gnupg curl -y
+RUN curl https://linux-clients.seafile.com/seafile.asc -o /usr/share/keyrings/seafile-keyring.asc
+RUN echo deb [arch=amd64 signed-by=/usr/share/keyrings/seafile-keyring.asc] https://linux-clients.seafile.com/seafile-deb/bullseye/ stable main | tee /etc/apt/sources.list.d/seafile.list
+RUN apt-get update -y
+RUN apt-get install -y seafile-cli procps grep
+RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get clean
 
 WORKDIR /seafile-client
 
 COPY start.sh /seafile-client/start.sh
 
-RUN chmod +x /seafile-client/start.sh && \
-    useradd -U -d /seafile-client -s /bin/bash seafile && \
-    usermod -G users seafile && \
-    chown seafile:seafile -R /seafile-client && \
-    su - seafile -c "seaf-cli init -d /seafile-client"
+RUN chmod +x /seafile-client/start.sh
+RUN useradd -U -d /seafile-client -s /bin/bash seafile
+RUN usermod -G users seafile
+RUN chown seafile:seafile -R /seafile-client
+RUN su - seafile -c "seaf-cli init -d /seafile-client"
 
 CMD ["./start.sh"]

--- a/Notes.txt
+++ b/Notes.txt
@@ -1,0 +1,2 @@
+There is a more active client here:
+https://gitlab.com/florian.anceau-oss/docker-seafile-client

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Run a seafile client inside docker which can sync files from seafile repositorie
 See docker-compose how to use.
 
 ## Environment variables:
+ - context=./docker-seafile-client   The path to the directory containing `Dockerfile` and `start.sh`
  - LIBRARY_ID=your-library-id-here   Can be multiple library ids seperated with colon :
  - SERVER_URL=server-url             The url used to access your server, eg: https://example.seafile.com
  - SERVER_PORT=server-port           Which port the server is hosted on: usually 443 (https) or 80 (http)

--- a/README.md
+++ b/README.md
@@ -4,16 +4,25 @@ Run a seafile client inside docker which can sync files from seafile repositorie
 See docker-compose how to use.
 
 ## Environment variables:
- - context=./docker-seafile-client   The path to the directory containing `Dockerfile` and `start.sh`
- - LIBRARY_ID=your-library-id-here   Can be multiple library ids seperated with colon :
- - SERVER_URL=server-url             The url used to access your server, eg: https://example.seafile.com
- - SERVER_PORT=server-port           Which port the server is hosted on: usually 443 (https) or 80 (http)
- - USERNAME=username                 Your account username (credentials)
- - PASSWORD=password                 Your account password (credentials)
- - DATA_DIR=directory-path-to-sync   The path where to put the files
- - CONNECT_RETRIES=number            How many times try to connect to daemon. Higher value is useful on slow boxes. Default is 5
- - DISABLE_VERIFY_CERTIFICATE=true   Disable certificate validation. In case you connect to a server with a self-signed certificate
-                                     ! Do not use to connect to public server on the internet ! Use a trusted certificate provider instead.
+ - `context` 
+    - The path to the directory containing `Dockerfile` and `start.sh`
+ - LIBRARY_ID
+    - Can be multiple library ids separated with colon :
+ - SERVER_URL
+    - The url used to access your server, eg: https://example.seafile.com
+ - SERVER_PORT
+    - Which port the server is hosted on: usually 443 (https) or 80 (http)
+ - USERNAME & PASSWORD
+    - Your seafile's account username and password (credentials)
+ - CONNECT_RETRIES (optional)
+    - How many times try to connect to daemon. Higher value is useful on slow boxes. Default is 5
+ - DISABLE_VERIFY_CERTIFICATE (optional)
+    - (Default: false) Disable certificate validation. In case you connect to a server with a self-signed certificate. ! Do not use to connect to public server on the internet ! Use a trusted certificate provider instead.
+ - `<library-host-volume-path>`
+    - The path to the directory containing the libraries to sync
+ - `<sync-state-host-volume-path>` (optional)
+    - (Recommended, use a persistent docker volume. If unused, delete the line.) The path to the directory where seafile-client saves state (so that you can re-instantiate/move the container and client should avoid having conflicts in the library because of attempting to sync an existing local library that is different than the server)
+
 ## How to find library id:
 
 <img src="imgs/help.png"/>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,12 @@ version: '2'
 services:
   seafile-client:
     restart: always
-    image: gronis/seafile-client
+    build:
+        # Context should not be a folder that contains all of your seafile librariers
+        # otherwise it will take docker forever to find the Dockerfile (or something).
+        # context should point to the folder that contains the Dockerfile and start.sh.
+        context: <path-to-dockerfile-and-start.sh>
+    image: seafile-client
     container_name: seafile-client
     environment:
       - LIBRARY_ID=<your-library-id-here>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
         # Context should not be a folder that contains all of your seafile librariers
         # otherwise it will take docker forever to find the Dockerfile (or something).
         # context should point to the folder that contains the Dockerfile and start.sh.
-        context: <path-to-dockerfile-and-start.sh>
+        context: ./docker-seafile-client
     image: seafile-client
     container_name: seafile-client
     environment:
@@ -15,6 +15,6 @@ services:
       - SERVER_PORT=<server-port>
       - USERNAME=<username>
       - PASSWORD=<password>
-      - DATA_DIR=<directory-path-to-sync>
     volumes:
-      - <host-volume-path>:<directory-path-to-sync>
+      - <library-host-volume-path>:/libraries
+      - <sync-state-host-volume-path>:/seafile-client

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,4 +17,4 @@ services:
       - PASSWORD=<password>
     volumes:
       - <library-host-volume-path>:/libraries
-      - <sync-state-host-volume-path>:/seafile-client
+      - <sync-state-host-volume-path>:/seafile-state

--- a/start.sh
+++ b/start.sh
@@ -112,7 +112,7 @@ keep_in_foreground() {
   # leading to a script abortion thanks to "set -e".
   while true
   do
-    for SEAFILE_PROC in "ccnet" "seaf-daemon"
+    for SEAFILE_PROC in "seaf-daemon"
     do
       pkill -0 -f "${SEAFILE_PROC}"
       sleep 1

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@ set -e
 set -u
 set -o pipefail
 
-DATA_DIR="${DATA_DIR:-/data}"
+LIBRARY_DIR="/libraries"
 SEAFILE_UID="${SEAFILE_UID:-1000}"
 SEAFILE_GID="${SEAFILE_GID:-1000}"
 SEAFILE_UMASK="${SEAFILE_UMASK:-022}"
@@ -47,10 +47,10 @@ get () {
 }
 
 setup_lib_sync(){
-    if [ ! -d $DATA_DIR ]; then
-      echo "Using new data directory: $DATA_DIR"
-      mkdir -p $DATA_DIR
-      chown seafile:seafile -R $DATA_DIR
+    if [ ! -d $LIBRARY_DIR ]; then
+      echo "Using new data directory: $LIBRARY_DIR"
+      mkdir -p $LIBRARY_DIR
+      chown seafile:seafile -R $LIBRARY_DIR
     fi
     TOKEN_JSON=$(curl -d "username=$USERNAME" -d "password=$PASSWORD" ${SERVER_URL}:${SERVER_PORT}/api2/auth-token/ 2> /dev/null)
     TOKEN=$(get token "$TOKEN_JSON")
@@ -66,7 +66,7 @@ setup_lib_sync(){
       LIB_JSON=$(curl -G -H "Authorization: Token $TOKEN" -H 'Accept: application/json; indent=4' ${SERVER_URL}:${SERVER_PORT}/api2/repos/${LIB}/ 2> /dev/null)
       LIB_NAME=$(get name "$LIB_JSON")
       LIB_NAME_NO_SPACE=$(echo $LIB_NAME|sed 's/[ \(\)]/_/g')
-      LIB_DIR=${DATA_DIR}/${LIB_NAME_NO_SPACE}
+      LIB_DIR=${LIBRARY_DIR}/${LIB_NAME_NO_SPACE}
       set +e
       LIB_IN_SYNC=$(echo "$LIBS_IN_SYNC" | grep "$LIB")
       set -e


### PR DESCRIPTION
The persistent state (optional) is useful for preventing any sync conflicts if libraries are modified while the client is down.